### PR TITLE
Downgrade to Python 3.9

### DIFF
--- a/test/movie/TestMVS.py
+++ b/test/movie/TestMVS.py
@@ -3,6 +3,7 @@ from unittest import mock
 import unittest.mock
 from unittest.mock import call
 import os
+import sys
 
 from src.movie.mvs import MVS
 from src.movie.movie import Movie
@@ -20,14 +21,24 @@ class TestMVS(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.enterClassContext(
-            unittest.mock.patch.dict(os.environ, {
-                "TMDB_API_KEY": "abc",
-                "SPOTIFY_CLIENT_ID": "123",
-                "SPOTIFY_CLIENT_SECRET": "456"
-                }
+        if sys.version_info[:3] > (3, 10):
+            cls.enterClassContext(
+                unittest.mock.patch.dict(os.environ, {
+                    "TMDB_API_KEY": "abc",
+                    "SPOTIFY_CLIENT_ID": "123",
+                    "SPOTIFY_CLIENT_SECRET": "456"
+                    }
+                )
             )
-        )
+        else:
+            with unittest.mock.patch.dict(os.environ, {
+                    "TMDB_API_KEY": "abc",
+                    "SPOTIFY_CLIENT_ID": "123",
+                    "SPOTIFY_CLIENT_SECRET": "456"
+                    }):
+                print(
+                    f"We currently use python version {sys.version} for unit test."
+                    )
         return super().setUpClass()
     
     """Test init function."""

--- a/test/movie/TestMVS.py
+++ b/test/movie/TestMVS.py
@@ -3,7 +3,6 @@ from unittest import mock
 import unittest.mock
 from unittest.mock import call
 import os
-import sys
 
 from src.movie.mvs import MVS
 from src.movie.movie import Movie
@@ -13,32 +12,32 @@ from src.music_user.user import User
 
 class TestMVS(unittest.TestCase):
     
+    @unittest.mock.patch.dict(os.environ, {
+                    "TMDB_API_KEY": "abc",
+                    "SPOTIFY_CLIENT_ID": "123",
+                    "SPOTIFY_CLIENT_SECRET": "456"
+                    }
+                )
     def setUp(self):
         with unittest.mock.patch.object(
             Movie, "test_api_connection", return_value=True
         ):
             self.mvs = MVS()
 
+    # As for python version > 3.11
+    # @classmethod
+    # def setUpClass(cls):
+    #     cls.enterClassContext(
+    #             unittest.mock.patch.dict(os.environ, {
+    #                 "TMDB_API_KEY": "abc",
+    #                 "SPOTIFY_CLIENT_ID": "123",
+    #                 "SPOTIFY_CLIENT_SECRET": "456"
+    #                 }
+    #             )
+    #         )
+
     @classmethod
     def setUpClass(cls):
-        if sys.version_info[:3] > (3, 10):
-            cls.enterClassContext(
-                unittest.mock.patch.dict(os.environ, {
-                    "TMDB_API_KEY": "abc",
-                    "SPOTIFY_CLIENT_ID": "123",
-                    "SPOTIFY_CLIENT_SECRET": "456"
-                    }
-                )
-            )
-        else:
-            with unittest.mock.patch.dict(os.environ, {
-                    "TMDB_API_KEY": "abc",
-                    "SPOTIFY_CLIENT_ID": "123",
-                    "SPOTIFY_CLIENT_SECRET": "456"
-                    }):
-                print(
-                    f"We currently use python version {sys.version} for unit test."
-                    )
         return super().setUpClass()
     
     """Test init function."""

--- a/test/movie/TestMovie.py
+++ b/test/movie/TestMovie.py
@@ -24,7 +24,9 @@ class TestMovie(unittest.TestCase):
             )
         else:
             with unittest.mock.patch.dict(os.environ, {"TMDB_API_KEY": "abc"}):
-                cls.assertEqual(os.environ['TMDB_API_KEY'], 'abc')
+                print(
+                    f"We currently use python version {sys.version} for unit test."
+                    )
 
         return super().setUpClass()
     

--- a/test/movie/TestMovie.py
+++ b/test/movie/TestMovie.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import sys
 from unittest import mock
 import unittest.mock
 
@@ -17,9 +18,14 @@ class TestMovie(unittest.TestCase):
         
     @classmethod
     def setUpClass(cls):
-        cls.enterClassContext(
-            unittest.mock.patch.dict(os.environ, {"TMDB_API_KEY": "abc"})
-        )
+        if sys.version_info[:3] > (3, 10):
+            cls.enterClassContext(
+                unittest.mock.patch.dict(os.environ, {"TMDB_API_KEY": "abc"})
+            )
+        else:
+            with unittest.mock.patch.dict(os.environ, {"TMDB_API_KEY": "abc"}):
+                cls.assertEqual(os.environ['TMDB_API_KEY'], 'abc')
+
         return super().setUpClass()
     
     """Test init function."""

--- a/test/movie/TestMovie.py
+++ b/test/movie/TestMovie.py
@@ -1,6 +1,5 @@
 import unittest
 import os
-import sys
 from unittest import mock
 import unittest.mock
 
@@ -9,6 +8,7 @@ from test.helper import *
     
 class TestMovie(unittest.TestCase):   
 
+    @unittest.mock.patch.dict(os.environ, {"TMDB_API_KEY": "abc"})
     def setUp(self):
         self.maxDiff = None
         with unittest.mock.patch.object(
@@ -16,18 +16,15 @@ class TestMovie(unittest.TestCase):
             ):
                 self.movie = Movie()
         
+    # As for python version > 3.11
+    # @classmethod
+    # def setUpClass(cls):
+    #     cls.enterClassContext(
+    #         unittest.mock.patch.dict(os.environ, {"TMDB_API_KEY": "abc"})
+    #     ) 
+
     @classmethod
     def setUpClass(cls):
-        if sys.version_info[:3] > (3, 10):
-            cls.enterClassContext(
-                unittest.mock.patch.dict(os.environ, {"TMDB_API_KEY": "abc"})
-            )
-        else:
-            with unittest.mock.patch.dict(os.environ, {"TMDB_API_KEY": "abc"}):
-                print(
-                    f"We currently use python version {sys.version} for unit test."
-                    )
-
         return super().setUpClass()
     
     """Test init function."""


### PR DESCRIPTION
Blocking `unittest` 3.11 feature (`enterClassContext`). 